### PR TITLE
fix: LS implementation

### DIFF
--- a/src/components/UserArgHistory/UserArgHistory.tsx
+++ b/src/components/UserArgHistory/UserArgHistory.tsx
@@ -4,7 +4,7 @@ import { getDataFromLS } from "../../utils/services/helperFunctions/helperFuntio
 import Link from "next/link";
 import "./UserArgHistory.scss";
 
-const MAX_ITEMS = 25;
+const PREFIX = "userInput";
 
 const UserHistory: React.FC = () => {
   const [history, setHistory] = useState<string[]>([]);
@@ -12,8 +12,19 @@ const UserHistory: React.FC = () => {
   useEffect(() => {
     const loadHistory = () => {
       const items: string[] = [];
-      for (let i = 1; i <= MAX_ITEMS; i++) {
-        const data = getDataFromLS(i);
+
+      // Collect and sort keys in descending order
+      const sortedKeys = Object.keys(localStorage)
+        .filter((key) => key.startsWith(PREFIX))
+        .sort(
+          (a, b) =>
+            parseInt(b.substring(PREFIX.length)) -
+            parseInt(a.substring(PREFIX.length))
+        );
+
+      // Fetch data in sorted order
+      for (const key of sortedKeys) {
+        const data = localStorage.getItem(key);
         if (data) {
           try {
             items.push(data);
@@ -22,6 +33,7 @@ const UserHistory: React.FC = () => {
           }
         }
       }
+
       setHistory(items);
     };
 

--- a/src/utils/services/helperFunctions/helperFuntions.ts
+++ b/src/utils/services/helperFunctions/helperFuntions.ts
@@ -32,16 +32,18 @@ export function getTimeDescription(timestamp: FirestoreTimestamp): string {
 }
 
 const PREFIX = "userInput";
-const MAX_ITEMS = 25;
+const MAX_SIZE = 4 * 1024 * 1024; // 4MB in bytes
 
 export const storeDataInLS = (userInput: string): void => {
   const newKeyNumber = getNextAvailableKeyNumber();
   const newKey = `${PREFIX}${newKeyNumber}`;
 
-  if (getNumberOfStoredItems() >= MAX_ITEMS) {
+  while (getTotalSize() + getSizeInBytes(userInput) > MAX_SIZE) {
     const oldestKey = getOldestKey();
     if (oldestKey) {
       localStorage.removeItem(oldestKey);
+    } else {
+      break;
     }
   }
 
@@ -86,6 +88,23 @@ export const getOldestKey = (): string | null => {
 export const getDataFromLS = (keyNumber: number): string | null => {
   const key = `${PREFIX}${keyNumber}`;
   return localStorage.getItem(key);
+};
+
+export const getSizeInBytes = (value: string): number => {
+  return new Blob([value]).size;
+};
+
+export const getTotalSize = (): number => {
+  let totalSize = 0;
+  for (const key in localStorage) {
+    if (localStorage.hasOwnProperty(key) && key.startsWith(PREFIX)) {
+      const value = localStorage.getItem(key);
+      if (value !== null) {
+        totalSize += getSizeInBytes(value);
+      }
+    }
+  }
+  return totalSize;
 };
 
 const sampleArguments = {


### PR DESCRIPTION
This commit fixes local storage implementation by removing prior values if the size of the user added inputs exceeds 4MB. Thus, removing the previous arbitrary max item number(25).