### PR TITLE
Fix/ql calculator

### DIFF
--- a/src/utils/helperFunctions/deductionHelperFunctions/deductionHelperFunctions.test.ts
+++ b/src/utils/helperFunctions/deductionHelperFunctions/deductionHelperFunctions.test.ts
@@ -405,6 +405,35 @@ describe("isPremiseInQuantifierEnclosure", () => {
     const result = isPremiseInQuantifierEnclosure(premise);
     expect(result).toEqual(expectedOutput);
   });
+  it("test 11", () => {
+    const premise = ["\u2203(y)", "(", "Py", "->", "Ayy", ")"];
+    const expectedOutput = true;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 12", () => {
+    const premise = ["Wa", "->", "\u2200(y)", "(", "Gy", "->", "Aay", ")"];
+    const expectedOutput = false;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("test 13", () => {
+    const premise = ["\u2203(x)", "Gx", "&", "Axf"];
+    const expectedOutput = false;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 14", () => {
+    const premise = ["\u2203(a)", "Aa + Bb"];
+    const expectedOutput = true;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
 });
 
 export {};

--- a/src/utils/helperFunctions/deductionHelperFunctions/deductionHelperFunctions.test.ts
+++ b/src/utils/helperFunctions/deductionHelperFunctions/deductionHelperFunctions.test.ts
@@ -3,6 +3,7 @@ import {
   getBracketedNegation,
   getNegatedBiconditionalCasesToExist,
   getTranspose,
+  isPremiseInQuantifierEnclosure,
   searchInDS,
 } from "./deductionHelperFunctions";
 
@@ -316,6 +317,92 @@ describe("getNegatedBiconditionalCasesToExist", () => {
     ];
 
     const result = getNegatedBiconditionalCasesToExist(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+});
+
+describe("isPremiseInQuantifierEnclosure", () => {
+  it("test 1", () => {
+    const premise = ["P", "<->", "Q"];
+    const expectedOutput = false;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 2", () => {
+    const premise = ["∀y", "∀x", "(", "Pxy", ")"];
+    const expectedOutput = true;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 3", () => {
+    const premise = ["∀y", "Px", "->", "(", "Pxy", ")"];
+    const expectedOutput = false;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("test 4", () => {
+    const premise = ["∀(x)", "(", "Qx", ")", "&", "∀(x)", "(", "Px", ")"];
+    const expectedOutput = false;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 5", () => {
+    const premise = ["∀y", "(", "Aag", "&", "Agy", ")", "->", "Aay"];
+    const expectedOutput = false;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 6", () => {
+    const premise = [
+      "∀y",
+      "(",
+      "Wf",
+      "->",
+      "∀y",
+      "(",
+      "Gy",
+      "->",
+      "Afy",
+      ")",
+      ")",
+    ];
+    const expectedOutput = true;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 7", () => {
+    const premise = ["~", "(", "∃(x)", "(", "Gx", "&", "Axf", ")", ")"];
+    const expectedOutput = true;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 8", () => {
+    const premise = ["∃(x)", "(", "Axf", "&", "Afx", ")"];
+    const expectedOutput = true;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 9", () => {
+    const premise = ["∃(x)", "Afx"];
+    const expectedOutput = true;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
+    expect(result).toEqual(expectedOutput);
+  });
+  it("test 10", () => {
+    const premise = ["~", "(", "∃(x)", "Afx", ")"];
+    const expectedOutput = true;
+
+    const result = isPremiseInQuantifierEnclosure(premise);
     expect(result).toEqual(expectedOutput);
   });
 });

--- a/src/utils/helperFunctions/deductionHelperFunctions/deductionHelperFunctions.ts
+++ b/src/utils/helperFunctions/deductionHelperFunctions/deductionHelperFunctions.ts
@@ -535,3 +535,56 @@ export function convertKBToDeductionSteps(arrays: string[][]): DeductionStep[] {
     from: 0,
   }));
 }
+
+export function isPremiseInQuantifierEnclosure(premise: string[]): boolean {
+  if (premise.length === 0) return false;
+  const containsQuantifier = premise.some(
+    (el) => el.includes("\u2203") || el.includes("\u2200")
+  );
+
+  if (!containsQuantifier) return false;
+  const operator = getOperator(premise);
+  if ((!operator || operator === "~") && premise.length <= 3) return true;
+  const firstOpeningBracket = premise.indexOf("(");
+  const [before, after] = splitArray(premise, "(");
+  const lastElement = premise[premise.length - 1];
+  const hasClosingBracket = lastElement === ")";
+
+  if (!hasClosingBracket && !operator) return true;
+  if (!hasClosingBracket) return false;
+
+  const supposedOperator = getOperator(before);
+  const beforeOperator = supposedOperator && supposedOperator !== "~";
+
+  const areBracketsBalanced = isBalancedPair(
+    premise.slice(firstOpeningBracket)
+  );
+
+  return !beforeOperator && areBracketsBalanced;
+}
+
+function isBalancedPair(brackets: string[]): boolean {
+  if (brackets.length < 2) {
+    return false;
+  }
+
+  let openCount = 0;
+
+  if (brackets[0] !== "(" || brackets[brackets.length - 1] !== ")") {
+    return false;
+  }
+
+  for (let i = 0; i < brackets.length; i++) {
+    if (brackets[i] === "(") {
+      openCount++;
+    } else if (brackets[i] === ")") {
+      openCount--;
+    }
+
+    if (openCount === 0 && i !== brackets.length - 1) {
+      return false;
+    }
+  }
+
+  return openCount === 0;
+}

--- a/src/utils/quantifiableLogicUtils/inferThroughPermutations/inferThroughPermutations.test.ts
+++ b/src/utils/quantifiableLogicUtils/inferThroughPermutations/inferThroughPermutations.test.ts
@@ -1017,3 +1017,76 @@ describe("report-id: vSeIoabNKV3nuqQWPQQZ", () => {
     expect(result).toEqual(expected);
   });
 });
+
+describe("argument-id: nJk4TskzHUgf0xArQgUW ", () => {
+  it("main test", () => {
+    const premiseArr = ["∀x(Px) ∧ ∀x(Qx)"];
+    const conclusionArr = "∀x(Qx) ∧ ∀x(Px)";
+    const result = inferThroughPermutations(premiseArr, conclusionArr);
+    const expected = [
+      { from: "1", obtained: ["∀x", "(", "Px", ")"], rule: "Simplification" },
+      { from: "1", obtained: ["∀x", "(", "Qx", ")"], rule: "Simplification" },
+      {
+        from: "3,2",
+        obtained: ["∀x", "(", "Qx", ")", "&", "∀x", "(", "Px", ")"],
+        rule: "Conjunction",
+      },
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it("test 2", () => {
+    const premiseArr = ["∀x(Px)"];
+    const conclusionArr = "∀x(Px) | ∀x(Qx)";
+    const result = inferThroughPermutations(premiseArr, conclusionArr);
+    const expected = [
+      { from: "1", obtained: ["Pa"], rule: "Universal Instantiation" },
+      {
+        from: "1",
+        obtained: ["∀x", "(", "Px", ")", "|", "∀x", "(", "Qx", ")"],
+        rule: "Addition",
+      },
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it("test 3", () => {
+    const premiseArr = ["∀x(Px)"];
+    const conclusionArr = "Pa | Qa";
+    const result = inferThroughPermutations(premiseArr, conclusionArr);
+    const expected = [
+      { from: "1", obtained: ["Pa"], rule: "Universal Instantiation" },
+      { from: "2", obtained: ["Pa", "|", "Qa"], rule: "Addition" },
+    ];
+    expect(result).toEqual(expected);
+  });
+  it("test 4", () => {
+    const premiseArr = ["∀x(~Px)"];
+    const conclusionArr = "~Pa";
+    const result = inferThroughPermutations(premiseArr, conclusionArr);
+    const expected = [
+      { from: "1", obtained: ["~Pa"], rule: "Universal Instantiation" },
+    ];
+    expect(result).toEqual(expected);
+  });
+  it("test 5", () => {
+    const premiseArr = ["∀x(~Px | Rx)"];
+    const conclusionArr = "\u2200x(Px -> Rx)";
+    const result = inferThroughPermutations(premiseArr, conclusionArr);
+    const expected = [
+      {
+        from: "1",
+        obtained: ["~Pa", "|", "Ra"],
+        rule: "Universal Instantiation",
+      },
+      { from: "2", obtained: ["Pa", "->", "Ra"], rule: "Material Implication" },
+      {
+        from: "3",
+        obtained: ["∀x", "(", "Px", "->", "Rx", ")"],
+        rule: "Universal Generalization",
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/utils/quantifiableLogicUtils/inferThroughPermutations/inferThroughPermutations.ts
+++ b/src/utils/quantifiableLogicUtils/inferThroughPermutations/inferThroughPermutations.ts
@@ -159,8 +159,8 @@ const getDeductionStepsIfConcIsDerivable = (
   usedSubstitutes: string[]
 ) => {
   const deductionSteps = checkWithQuantifiableConclusion(
-    deductionStepsArr,
     conclusionArr,
+    deductionStepsArr,
     usedSubstitutes
   );
   if (deductionSteps) {

--- a/src/utils/sharedFunctions/checkKnowledgeBase/checkKnowledgeBase.test.ts
+++ b/src/utils/sharedFunctions/checkKnowledgeBase/checkKnowledgeBase.test.ts
@@ -44,6 +44,33 @@ describe("check knowledge base", () => {
       expected
     );
   });
+
+  it("test 3", () => {
+    const expected = [
+      { from: 0, obtained: ["∀x", "(", "Qx", ")"], rule: "premise" },
+      {
+        from: "0",
+        obtained: ["∀x", "(", "Qx", ")", "|", "∀x", "(", "Px", ")"],
+        rule: "Addition",
+      },
+    ];
+    const deductionSteps = convertKBToDeductionSteps([["∀x", "(", "Qx", ")"]]);
+
+    expect(
+      checkKnowledgeBase(
+        ["∀x", "(", "Qx", ")", "|", "∀x", "(", "Px", ")"],
+        deductionSteps
+      )
+    ).toEqual(expected);
+  });
+  it("test 4", () => {
+    const deductionSteps = [
+      { obtained: ["∀(x)", "(", "Px", ")"], rule: "premise", from: 0 },
+      { obtained: ["Pa"], rule: "Universal Instantiation", from: "0" },
+    ];
+
+    expect(checkKnowledgeBase(["~Pa"], deductionSteps)).toEqual(false);
+  });
 });
 
 export {};

--- a/src/utils/sharedFunctions/checkKnowledgeBase/checkKnowledgeBase.ts
+++ b/src/utils/sharedFunctions/checkKnowledgeBase/checkKnowledgeBase.ts
@@ -1,6 +1,7 @@
 import {
   convertImplicationToDisjunction,
   getOperator,
+  isPremiseInQuantifierEnclosure,
   searchInArray,
   searchInDS,
 } from "../../helperFunctions/deductionHelperFunctions/deductionHelperFunctions";
@@ -40,7 +41,9 @@ const checkKnowledgeBase = (
     if (premise[i].includes("\u2200") || premise[i].includes("\u2203")) {
       const alreadyExistsInKB = searchInDS(deductionStepsArr, premise);
       if (alreadyExistsInKB) return deductionStepsArr;
-      else return false;
+      else if (isPremiseInQuantifierEnclosure(premise)) {
+        return false;
+      }
     }
   }
 

--- a/src/utils/sharedFunctions/expandKnowledgeBase/expandKnowledgeBase.ts
+++ b/src/utils/sharedFunctions/expandKnowledgeBase/expandKnowledgeBase.ts
@@ -4,10 +4,12 @@ import {
   convertImplicationToDisjunction,
   getOperator,
   getSearchIndexInDS,
+  isPremiseInQuantifierEnclosure,
   searchInArray,
   searchInDS,
   searchIndex,
 } from "../../helperFunctions/deductionHelperFunctions/deductionHelperFunctions";
+import { isWffQuantified } from "../../pLTreeUtils/pLTHelperFunctions/pLTHelperFunctions";
 import { getInstantiation } from "../../quantifiableLogicUtils/inferDeductionStepsHelperFunctions/inferDeductionStepsHelperFunctions";
 import checkDisjunctionSolvability from "../checkDisjunctionSolvability/checkDisjunctionSolvability";
 import checkImplicationSolvability from "../checkImplicationSolvability/checkImplicationSolvability";
@@ -47,13 +49,15 @@ const expandKnowledgeBase = (
   for (let i = 0; i < simplifiableExpressions.length; i++) {
     const premise = simplifiableExpressions[i];
     const operator = getOperator(premise);
+    const isPremiseQuantified = isPremiseInQuantifierEnclosure(premise);
 
     if (alreadyInstantiatedPremises && combinations) {
+      // !operator to check for quantified premises of the form ∀x(Px) ∧ ∀x(Qx)
       if (premise[0].includes("\u2203")) {
         if (usedSubstitutes?.length === 0) continue;
         if (searchInArray(alreadyInstantiatedPremises, premise)) {
           continue;
-        } else {
+        } else if (isPremiseQuantified) {
           const substitute = usedSubstitutes?.shift();
           if (!substitute) continue;
           const existentialSub = `_${substitute}`; //??
@@ -81,7 +85,7 @@ const expandKnowledgeBase = (
         if (searchInArray(alreadyInstantiatedPremises, premise)) {
           // simplifiableExpressions.splice(l, 0);
           continue;
-        } else {
+        } else if (isPremiseQuantified) {
           const substitute = combinations.shift();
           if (!substitute) return false;
 


### PR DESCRIPTION
This PR adds a fix for backward chaining and expansion for quantified statements by introducing checks to differentiate between when an operator is the main connective vs when a quantifier is i.e., [ ∀xPx ∧ Fa ] vs  [∀x ( Px ∧ Fa ) ] and processing the argument accordingly.